### PR TITLE
add documentation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - API documentation
 - Full static typing, expanded file paths to support Path or str types.
+- Full external documentation pages
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,153 +1,33 @@
 # Jupyter SCAD: SCAD in Jupyter
 
+
 Jupyter SCAD renders and interactively visualizes 3D objects described in [SolidPython2](https://github.com/jeff-dh/SolidPython) within a Jupyter notebook.
 
 This program is focused on the use case of generating stl files with Python (aka SolidPython2) interactively within a Jupyter notebook.
 
-SolidPython2 generates [OpenSCAD language](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual#The_OpenSCAD_Language_Reference) code from Python code. Jupyter SCAD then uses [OpenSCAD](https://openscad.org) to render the OpenSCAD code to a 3D model and provides interactive visualization. As an alternative to SolidPython2, the OpenSCAD code can also be provided directly.
+## documentation
 
-## Installation
+Documentation is hosted at https://jreiberkyle.github.io/jupyterscad/.
 
-To simply install the package, use pip:
+## Quick Start
 
-```
+Jupyter SCAD can be installed with `pip`:
+
+```console
 pip install jupyterscad
 ```
 
-Alternatively, use [container-jupyterscad](https://github.com/jreiberkyle/container-jupyterscad) to run Jupyter SCAD and a pinned version
-of SolidPython2 in Jupyter lab in a [podman](https://podman.io/) container.
-
-## Usage
-
-### Define an OpenSCAD object
-
-An OpenSCAD object can be defined using SolidPython2 or OpenSCAD.
-
-#### SolidPython2
-```python
-from solid2 import cube
-obj = cube([1.5,2,1],center=True)
-```
-
-#### OpenSCAD
-```python
-obj = 'cube([1.5,2,1],center=true);'
-```
-
-Note: If a 3D object description integrates an external stl file, then the stl must be in the same directory as the notebook running the code.
-
-See the [OpenSCAD language](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual#The_OpenSCAD_Language_Reference) and [SolidPython2](https://github.com/jeff-dh/SolidPython) pages for more information on how to use these tools.
-
-### Render an OpenSCAD object
+An OpenSCAD object can be defined using SolidPython2, visualized in a Jupyter
+notebook, and saved to an `stl` file with:
 
 ```python
 from jupyterscad import render
+from solid2 import cube
 
-render(obj)
+render(cube([1.5,2,1],center=True), outfile='cube.stl')
 ```
-where `obj` is described in OpenSCAD as described above.
 
 ![render example](https://github.com/jreiberkyle/jupyterscad/blob/main/images/render_cube.png?raw=True)
-
-The stl generated in rendering can also be saved by defining 'outfile':
-```python
-render(obj, outfile='obj.stl')
-```
-
-### Visualize and then Render a stl
-
-```python
-from jupyterscad import visualize_stl, render_stl
-
-render_stl(obj, 'obj.stl')
-visualize_stl('obj.stl')
-```
-
-These separate steps allow for generating an stl from an OpenSCAD object without
-visualization or visualizing an existing stl. This is an example only, usually
-these steps would not be run together. To generate a stl while also visualizing
-the stl, use `render` with `outfile` specified.
-
-### API Docs
-
-#### render
-
-    render(
-        obj,
-        width: int = 400,
-        height: int = 400,
-        grid_unit: float = 1,
-        outfile: Optional[Union[str, PathLike]] = None,
-        openscad_exec: Optional[Union[str, PathLike]] = None,
-    )
-
-    Render a visusualization of an OpenSCAD object.
-
-    Typical usage example:
-
-      obj = cube(3)
-      r = render(obj)
-      display(r)
-
-    Args:
-        obj: OpenSCAD object to visualize.
-        width: Visualization pixel width on page.
-        height: Visualization pixel height on page.
-        grid_unit: Grid cell size.
-        outfile: Name of stl file to generate. No stl file is generated if None.
-        openscad_exec: Path to openscad executable.
-
-    Returns:
-        Rendering to be displayed.
-
-    Raises:
-        OpenSCADException: An error occurred running OpenSCAD.
-
-#### render_stl
-    render_stl(
-        obj,
-        output_file: Union[str, PathLike],
-        openscad_exec: Optional[Union[str, PathLike]] = None,
-    )
-
-    Render a stl from an OpenSCAD object.
-
-    Typical usage example:
-
-      obj = cube(3)
-      render_stl(obj, outfile='cube.stl')
-
-    Args:
-        obj: OpenSCAD object to visualize.
-        outfile: Name of stl file to generate. No stl file is generated if None.
-        openscad_exec: Path to openscad executable.
-
-    Raises:
-        OpenSCADException: An error occurred running OpenSCAD.
-
-#### visualize_stl
-    visualize_stl(
-        stl_file: Union[str, PathLike],
-        width: int = 400,
-        height: int = 400,
-        grid_unit: float = 1,
-    )
-
-    Render a visualization of a stl.
-
-    Typical usage example:
-
-      r = render('cube.stl')
-      display(r)
-
-    Args:
-        stl_file: stl file to visualize.
-        width: Visualization pixel width on page.
-        height: Visualization pixel height on page.
-        grid_unit: Grid cell size.
-
-    Returns:
-        Rendering to be displayed.
 
 
 ## Alternatives

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,12 @@
+---
+title: API Reference
+---
+
+::: jupyterscad.render
+    options:
+      show_source: false
+      heading_level: 2
+
+## ::: jupyterscad.render_stl
+
+## ::: jupyterscad.visualize_stl

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,11 +2,14 @@
 title: API Reference
 ---
 
-::: jupyterscad.render
-    options:
-      show_source: false
-      heading_level: 2
+## ::: jupyterscad.render
+    rendering:
+      show_root_full_path: false
 
 ## ::: jupyterscad.render_stl
+    rendering:
+      show_root_full_path: false
 
 ## ::: jupyterscad.visualize_stl
+    rendering:
+      show_root_full_path: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,25 +14,20 @@ Jupyter SCAD can be installed with `pip`:
 pip install jupyterscad
 ```
 
-An OpenSCAD object can be defined using SolidPython2.
-
-```python
-from solid2 import cube
-obj = cube([1.5,2,1],center=True)
-```
-
-And visualized with Jupyter SCAD `render`:
+An OpenSCAD object can be defined using SolidPython2, visualized in a Jupyter
+notebook, and saved to an `stl` file with:
 
 ```python
 from jupyterscad import render
+from solid2 import cube
 
-render(obj)
+render(cube([1.5,2,1],center=True), outfile='cube.stl')
 ```
 
 ![render example](https://github.com/jreiberkyle/jupyterscad/blob/main/images/render_cube.png?raw=True)
 
-The stl generated in rendering can also be saved by defining 'outfile':
+See the [Usage](usage.md) page for more examples.
 
-```python
-render(obj, outfile='obj.stl')
-```
+## License
+
+Jupyter SCAD is licensed under the [GNU GENERAL PUBLIC LICENSE](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Jupyter SCAD
+
+Jupyter SCAD renders and interactively visualizes 3D objects described in [SolidPython2](https://github.com/jeff-dh/SolidPython) within a Jupyter notebook.
+
+This program is focused on the use case of generating stl files with Python (aka SolidPython2) interactively within a Jupyter notebook.
+
+SolidPython2 generates [OpenSCAD language](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual#The_OpenSCAD_Language_Reference) code from Python code. Jupyter SCAD then uses [OpenSCAD](https://openscad.org) to render the OpenSCAD code to a 3D model and provides interactive visualization. As an alternative to SolidPython2, the OpenSCAD code can also be provided directly.
+
+## Quick Start
+
+Jupyter SCAD can be installed with `pip`:
+
+```console
+pip install jupyterscad
+```
+
+An OpenSCAD object can be defined using SolidPython2.
+
+```python
+from solid2 import cube
+obj = cube([1.5,2,1],center=True)
+```
+
+And visualized with Jupyter SCAD `render`:
+
+```python
+from jupyterscad import render
+
+render(obj)
+```
+
+![render example](https://github.com/jreiberkyle/jupyterscad/blob/main/images/render_cube.png?raw=True)
+
+The stl generated in rendering can also be saved by defining 'outfile':
+
+```python
+render(obj, outfile='obj.stl')
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,70 @@
+# Usage Examples
+
+## Defining an OpenSCAD object
+
+An OpenSCAD object can be defined using SolidPython2 or OpenSCAD.
+
+### SolidPython2
+```python
+from solid2 import cube
+obj = cube([1.5,2,1],center=True)
+```
+
+### OpenSCAD
+```python
+obj = 'cube([1.5,2,1],center=true);'
+```
+
+Note: If a 3D object description integrates an external stl file, then the stl must be in the same directory as the notebook running the code.
+
+See the [OpenSCAD language](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual#The_OpenSCAD_Language_Reference) and [SolidPython2](https://github.com/jeff-dh/SolidPython) pages for more information on how to use these tools.
+
+## Rendering an OpenSCAD object
+
+### Visualizing and Rendering to an stl
+
+To visualize an OpenSCAD object, use `render`:
+```python
+from jupyterscad import render
+from solid2 import cube
+
+obj = cube([1.5,2,1],center=True)
+render(obj)
+```
+![render example](https://github.com/jreiberkyle/jupyterscad/blob/main/images/render_cube.png?raw=True)
+
+The rendering can also save the stl file by defining 'outfile':
+
+```python
+from jupyterscad import render
+from solid2 import cube
+
+obj = cube([1.5,2,1],center=True)
+render(obj, outfile='obj.stl')
+```
+
+### Adjusting grid size
+
+In `render` and `visualize_stl`, the default grid unit is 1. The grid unit can
+be set to e.g. `10` with `grid_unit=10`, disabled with `grid_unit=0` or set to
+automatic scaling with `grid_unit=-1`.
+
+
+### Rendering directly to an stl
+
+An stl can be generated directly without visualization with:
+
+```python
+from jupyterscad import render_stl
+
+render_stl(obj, 'obj.stl')
+```
+### Visualizing an stl
+
+A stl can be visualized with:
+
+```python
+from jupyterscad import visualize_stl
+
+visualize_stl('obj.stl')
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,32 @@
+site_name: Jupyter SCAD
+
+repo_name: jreiberkyle/jupyterscad
+repo_url: https://github.com/jreiberkyle/jupyterscad
+edit_uri: ""
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_root_heading: true
+            show_source: false
+            docstring_style: google
+            docstring_section_style: list
+
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,6 +76,22 @@ def analyze(session):
 
 
 @nox.session
+def serve(session):
+    """Build and serve live docs for editing"""
+    session.install("-e", ".[docs]")
+
+    session.run("mkdocs", "serve")
+
+
+@nox.session
+def deploy(session):
+    """Deploy docs to github pages"""
+    session.install("-e", ".[docs]")
+
+    session.run("mkdocs", "gh-deploy")
+
+
+@nox.session
 def build(session):
     """Build package"""
     # check preexisting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest", "solidpython2"]
+docs = ["mkdocs<2", "mkdocs-material<10", "mkdocstrings-python"]
 
 [project.urls]
 Homepage = "https://github.com/jreiberkyle/jupyterscad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ test = ["pytest", "solidpython2"]
 docs = ["mkdocs<2", "mkdocs-material<10", "mkdocstrings-python"]
 
 [project.urls]
-Homepage = "https://github.com/jreiberkyle/jupyterscad"
-Documentation = "https://github.com/jreiberkyle/jupyterscad"
+Homepage = "https://jreiberkyle.github.io/jupyterscad/"
+Documentation = "https://jreiberkyle.github.io/jupyterscad/"
 Repository = "https://github.com/jreiberkyle/jupyterscad"
 Changelog = "https://github.com/jreiberkyle/jupyterscad/blob/main/CHANGELOG.md"
 

--- a/src/jupyterscad/_render.py
+++ b/src/jupyterscad/_render.py
@@ -18,6 +18,8 @@ import tempfile
 from os import PathLike
 from typing import Optional, Union
 
+import pythreejs as pjs
+
 from ._openscad import process
 from ._visualize import visualize_stl
 
@@ -29,14 +31,12 @@ def render(
     grid_unit: float = 1,
     outfile: Optional[Union[str, PathLike]] = None,
     openscad_exec: Optional[Union[str, PathLike]] = None,
-):
+) -> pjs.Renderer:
     """Render a visusualization of an OpenSCAD object.
 
     Typical usage example:
 
-      obj = cube(3)
-      r = render(obj)
-      display(r)
+        >>> display(render(cube(3)))
 
     Args:
         obj: OpenSCAD object to visualize.
@@ -73,8 +73,7 @@ def render_stl(
 
     Typical usage example:
 
-      obj = cube(3)
-      render_stl(obj, outfile='cube.stl')
+        >>> render_stl(cube(3), outfile='cube.stl')
 
     Args:
         obj: OpenSCAD object to visualize.

--- a/src/jupyterscad/_visualize.py
+++ b/src/jupyterscad/_visualize.py
@@ -28,13 +28,12 @@ def visualize_stl(
     width: int = 400,
     height: int = 400,
     grid_unit: float = 1,
-):
+) -> pjs.Renderer:
     """Render a visualization of a stl.
 
     Typical usage example:
 
-      r = render('cube.stl')
-      display(r)
+        >>> display(visualize_stl(cube(3)))
 
     Args:
         stl_file: stl file to visualize.


### PR DESCRIPTION
Adds documentation at https://jreiberkyle.github.io/jupyterscad/ along with serving/deploying workflows in nox. Streamlines README and adds some usage.