### PR TITLE
release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-10-24
+
 ### Added
 
 - API documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyterscad"
-version = "0.2.0"
+version = "1.0.0dev"
 authors = [{name = "Jennifer Reiber Kyle"}]
 description = "Solid 3D Cad (SCAD) renderer and viewer for Jupyter"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyterscad"
-version = "0.1.3"
+version = "0.2.0"
 authors = [{name = "Jennifer Reiber Kyle"}]
 description = "Solid 3D Cad (SCAD) renderer and viewer for Jupyter"
 readme = "README.md"


### PR DESCRIPTION
### Added

- API documentation
- Full static typing, expanded file paths to support Path or str types.
- Full external documentation pages
- render and visualize_stl: add grid autoscaling when `grid_unit` is set to `-1` (#16). Thank you @jeff-dh!

### Fixed

- Grid was not aligned with origin for grid_unit != 1 (#11). Thank you @jeff-dh!
- README references to jupter_scad should be jupyterscad

## Changed

- OpenSCAD executable discovery now looks in PATH (which works for Linux) then
  in the macOS-specific install path if not found in PATH
- Rename render_stl out_file to outfile for positional arg to match other fcns