### PR TITLE
Report to stderr when OpenSCAD render encounters an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Output to stderr if openscad rendering encountered an error.
+
+
 ## [0.2.0] - 2023-10-24
 
 ### Added
@@ -27,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the macOS-specific install path if not found in PATH
 - Rename render_stl out_file to outfile for positional arg to match other fcns
 
+
 ## [0.1.0] - 2023-10-01
 
 ### Added
@@ -37,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - package files moved to src/ directory for autodetection
+
 
 ## [0.0.1] - 2023-09-29
 

--- a/src/jupyterscad/_openscad.py
+++ b/src/jupyterscad/_openscad.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from shutil import which
 from typing import Optional, Union
 
-from .exceptions import OpenSCADException
+from .exceptions import OpenSCADException, RenderError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,11 +36,19 @@ def process(scad_file, output_file, executable: Optional[Union[str, PathLike]] =
             )
     else:
         executable = detect_executable()
-
+    
     cmd = [executable, "-o", output_file, scad_file]
     LOGGER.info(cmd)
     try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if("ERROR" in out.stderr):
+            raise RenderError(out.stderr)
+            # import sys
+            # from warnings import warn; warn('\n'+out.stderr, stacklevel=2)
+            # print("ERROR", file=sys.stderr)
+            # print(out.stderr, file=sys.stderr)
+        # else:
+            # print(out.stderr)
     except subprocess.CalledProcessError as e:
         raise OpenSCADException(str(e.stderr))
 

--- a/src/jupyterscad/_render.py
+++ b/src/jupyterscad/_render.py
@@ -58,7 +58,9 @@ def render(
             render_stl(obj, outfile, openscad_exec=openscad_exec)
             r = visualize_stl(outfile, width=width, height=height, grid_unit=grid_unit)
         else:
-            with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as stl_tmp_file:
+            with tempfile.NamedTemporaryFile(
+                suffix=".stl", delete=False
+            ) as stl_tmp_file:
                 render_stl(obj, stl_tmp_file.name, openscad_exec=openscad_exec)
                 r = visualize_stl(
                     stl_tmp_file.name, width=width, height=height, grid_unit=grid_unit

--- a/src/jupyterscad/_render.py
+++ b/src/jupyterscad/_render.py
@@ -22,6 +22,7 @@ import pythreejs as pjs
 
 from ._openscad import process
 from ._visualize import visualize_stl
+from .exceptions import RenderError
 
 
 def render(
@@ -52,16 +53,19 @@ def render(
     Raises:
         exceptions.OpenSCADException: An error occurred running OpenSCAD.
     """
-    if outfile:
-        render_stl(obj, outfile, openscad_exec=openscad_exec)
-        r = visualize_stl(outfile, width=width, height=height, grid_unit=grid_unit)
-    else:
-        with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as stl_tmp_file:
-            render_stl(obj, stl_tmp_file.name, openscad_exec=openscad_exec)
-            r = visualize_stl(
-                stl_tmp_file.name, width=width, height=height, grid_unit=grid_unit
-            )
-    return r
+    try:
+        if outfile:
+            render_stl(obj, outfile, openscad_exec=openscad_exec)
+            r = visualize_stl(outfile, width=width, height=height, grid_unit=grid_unit)
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as stl_tmp_file:
+                render_stl(obj, stl_tmp_file.name, openscad_exec=openscad_exec)
+                r = visualize_stl(
+                    stl_tmp_file.name, width=width, height=height, grid_unit=grid_unit
+                )
+        return r
+    except RenderError as e:
+        e.show()
 
 
 def render_stl(

--- a/src/jupyterscad/exceptions.py
+++ b/src/jupyterscad/exceptions.py
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import sys
 
+
 class JupyterSCADError(Exception):
     pass
 
@@ -25,9 +26,10 @@ class OpenSCADError(JupyterSCADError):
 
 
 class RenderError(JupyterSCADError):
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, src: str) -> None:
         super().__init__(message)
         self.message = message
+        self.src = src
 
     def show(self) -> None:
-       print(self.message, file=sys.stderr)
+        print(f"{self.message}\nSCAD SOURCE:\n\n{self.src}", file=sys.stderr)

--- a/src/jupyterscad/exceptions.py
+++ b/src/jupyterscad/exceptions.py
@@ -14,11 +14,20 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 """
+import sys
 
-
-class JupyterSCADException(Exception):
+class JupyterSCADError(Exception):
     pass
 
 
-class OpenSCADException(JupyterSCADException):
+class OpenSCADError(JupyterSCADError):
     pass
+
+
+class RenderError(JupyterSCADError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def show(self) -> None:
+       print(self.message, file=sys.stderr)

--- a/tests/test_openscad.py
+++ b/tests/test_openscad.py
@@ -15,8 +15,8 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import logging
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_openscad.py
+++ b/tests/test_openscad.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import logging
+from pathlib import Path
 import subprocess
 
 import pytest
@@ -83,12 +84,17 @@ def test_process_invalid_scad(check_openscad, tmp_path, output_file):
 
 
 def test_process_render_error(monkeypatch, tmp_path, output_file):
+    monkeypatch.setattr(
+        _openscad, "detect_executable", lambda *arg, **kwarg: Path("openscad")
+    )
+
     error_msg = (
         "ERROR: The given mesh is not closed! Unable to convert to CGAL_Nef_Polyhedron"
     )
 
     mock_resp = subprocess.CompletedProcess(
-            args=None, returncode=0, stdout='', stderr=error_msg)
+        args=None, returncode=0, stdout="", stderr=error_msg
+    )
     monkeypatch.setattr(_openscad.subprocess, "run", lambda *arg, **kwarg: mock_resp)
 
     scad_str = "cube([3,3,3]);"


### PR DESCRIPTION
When OpenSCAD render encounters an error, the process completes successfully but a message starting with `ERROR` is included in the stderr. Propagate this error to the user.