### PR TITLE
release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.3.0] - 2023-10-27
+
 ### Changed
 
 - `render` renamed to `view`, `visualize_stl` renamed to `view_stl`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyterscad"
-version = "0.3.0"
+version = "0.3.1dev"
 authors = [{name = "Jennifer Reiber Kyle"}]
 description = "Solid 3D Cad (SCAD) renderer and viewer for Jupyter"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyterscad"
-version = "0.3.0dev"
+version = "0.3.0"
 authors = [{name = "Jennifer Reiber Kyle"}]
 description = "Solid 3D Cad (SCAD) renderer and viewer for Jupyter"
 readme = "README.md"


### PR DESCRIPTION
### Changed

- `render` renamed to `view`, `visualize_stl` renamed to `view_stl`.

### Added

- Output to stderr if openscad rendering encountered an error.